### PR TITLE
feat: Update to mg5_aMC v3.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ default: image
 all: image
 
 image:
-	docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.3.0
+	docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.3.1
 	docker build \
 		-f docker/Dockerfile \
-		-t matthewfeickert/smeft_mg5_amc:mg5_amc3.3.0 \
+		-t matthewfeickert/smeft_mg5_amc:mg5_amc3.3.1 \
 		-t matthewfeickert/smeft_mg5_amc:debug-latest \
 		.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MadGraph5_aMC@NLO with SMEFTsim models
 Pull from Docker Hub
 
 ```
-docker pull matthewfeickert/smeft_mg5_amc:mg5_amc3.3.0
+docker pull matthewfeickert/smeft_mg5_amc:mg5_amc3.3.1
 ```
 
 ## Build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc3.3.0
+ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc3.3.1
 FROM ${BASE_IMAGE} as base
 
 ARG TARGET_BRANCH=v3.0.2


### PR DESCRIPTION
Update to release [`v3.3.1` of MadGraph5_aMC-NLO](https://launchpad.net/mg5amcnlo/3.0/3.3.x) ~~and [`MG5aMC_PY8_interface` `v1.3`](http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.3.tar.gz)~~.

As a note to future self, this was made easy via the command line with

```console
git grep --name-only "3.3.0" | xargs sed -i 's/3.3.0/3.3.1/g'
```

```
* Update to MadGraph5_aMC-NLO v3.3.1
   - c.f. https://launchpad.net/mg5amcnlo/3.0/3.3.x/+download/MG5_aMC_v3.3.1.tar.gz
```